### PR TITLE
README: recommend last angular version supporting node v12

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Tested with node v12.22.7
 
-Requires Angular cli installed (npm install -g @angular/cli@latest)
+Requires Angular cli installed (npm install -g @angular/cli@13.3.x)
 
 # Set backend api
 


### PR DESCRIPTION
Current instructions recommend installing Node v12.22.7 and angular CLI `latest`, which are now incompatible as Angular 14 dropped support for Node <14.15.
This PR replaces `latest` with `13.3.x` which is the last Angular CLI version that supports Node v12.

(Node v12 reached EOL in April 2022, so while it's probably not a great idea to keep using it, at least this PR makes building and running the current main branch easier).